### PR TITLE
DI-447: Make compatible with multiple genome builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ chrom   start   end HGNC:ID Refseq_transcript_id    exon_nb
 
 ## Second script, refseq_g2t
 
-## <span style="color: red;">WARNING: RELEASE 1.2.0 HAS UPDATED THE FIRST SCRIPT (gff2tsv) BUT NOT THE SECOND (refseq_g2t)</span>
-<span style="color: red;">this version of the refseq_g2t script may not work with the new version of gff2tsv</span>
+> [!WARNING]
+> RELEASE 1.2.0 HAS UPDATED THE FIRST SCRIPT (gff2tsv) BUT NOT THE SECOND (refseq_g2t)
+> this version of the refseq_g2t script may not work with the new version of gff2tsv
 
 Script to check that g2t from new refseq gff is correct and generate a g2t from exon file from gff2tsv
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ chrom   start   end HGNC:ID Refseq_transcript_id    exon_nb
 ## Second script, refseq_g2t
 
 > [!WARNING]
-> RELEASE 1.2.0 HAS UPDATED THE FIRST SCRIPT (gff2tsv) BUT NOT THE SECOND (refseq_g2t)
+> Release 1.2.0 has updated the first script(gff2tsv) but not the second (refseq_g2t)
 > this version of the refseq_g2t script may not work with the new version of gff2tsv
+>
+> Please use with caution. Testing and validation will be needed before use with new gff2tsv script v1.2.0.
 
 Script to check that g2t from new refseq gff is correct and generate a g2t from exon file from gff2tsv
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ chrom   start   end HGNC:ID Refseq_transcript_id    exon_nb
 ## Second script, refseq_g2t
 
 > [!WARNING]
-> Release 1.2.0 has updated the first script(gff2tsv) but not the second (refseq_g2t)
+> Release 1.2.0 has updated the first script (gff2tsv) but not the second (refseq_g2t)
 > this version of the refseq_g2t script may not work with the new version of gff2tsv
 >
 > Please use with caution. Testing and validation will be needed before use with new gff2tsv script v1.2.0.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ CDS not gathered:
 
 ### How to run
 
-Tested only with a Refseq gff file
+Tested only with a Refseq gff file. Genome build should be input as '37' or '38'.
 
 ```bash
-python gff2tsv.py ${gff_file} [ -f ${flank} -o ${output_name} ]
+python gff2tsv.py ${gff_file} -f ${flank} -o ${output_name} -b ${genome_build}
 ```
 
 ### Outputs
@@ -46,6 +46,9 @@ chrom   start   end HGNC:ID Refseq_transcript_id    exon_nb
 ```
 
 ## Second script, refseq_g2t
+
+## <span style="color: red;">WARNING: RELEASE 1.2.0 HAS UPDATED THE FIRST SCRIPT (gff2tsv) BUT NOT THE SECOND (refseq_g2t)</span>
+<span style="color: red;">this version of the refseq_g2t script may not work with the new version of gff2tsv</span>
 
 Script to check that g2t from new refseq gff is correct and generate a g2t from exon file from gff2tsv
 

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -272,7 +272,7 @@ def write_tsv(db, data, transcripts_to_remove, gff, flank, refseq_chrom, output_
                 feature_nb = data[feature][0].id.split("-")[-1]
 
                 data_to_write.append([
-                    refseq_chrom[feature.seqid], feature.start - 1 - flank,
+                    refseq_chrom[feature.chrom], feature.start - 1 - flank,
                     feature.end + flank, hgnc_id, transcript, feature_nb
                 ])
 

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -153,7 +153,7 @@ def infer_exon_number(parents2cds, parents2exons):
                 for e in cds_w_exon_nb[cds]:
                     print(e)
                 exit()
-    print(len(cds_w_exon_nb.keys()))
+
     return cds_w_exon_nb
 
 

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -86,7 +86,7 @@ def get_parents2features(db, feature_type, refseq_chrom):
     print(f"Getting {feature_type}...")
 
     parents2features = {}
-    
+
     for feature in db.features_of_type(feature_type):
         # check if feature has multiple parents
         if len(feature.attributes["Parent"]) != 1:

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -86,9 +86,11 @@ def get_parents2features(db, feature_type, refseq_chrom):
     print(f"Getting {feature_type}...")
 
     parents2features = {}
+    
     for feature in db.features_of_type(feature_type):
         # check if feature has multiple parents
         if len(feature.attributes["Parent"]) != 1:
+            print(feature)
             continue
 
         # filter out some CDS because their parents were

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -224,7 +224,8 @@ def get_transcripts_to_remove(db, data):
     return transcripts_to_remove
 
 
-def write_tsv(db, data, transcripts_to_remove, gff, flank, refseq_chrom, output_name=None):
+def write_tsv(db, data, transcripts_to_remove, gff, flank, refseq_chrom,
+        output_name=None):
     """ Write tsv
 
     Args:

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -89,7 +89,6 @@ def get_parents2features(db, feature_type, refseq_chrom):
     for feature in db.features_of_type(feature_type):
         # check if feature has multiple parents
         if len(feature.attributes["Parent"]) != 1:
-            print(feature)
             continue
 
         # filter out some CDS because their parents were
@@ -117,7 +116,7 @@ def infer_exon_number(parents2cds, parents2exons):
         dict: cds2exon dict
     """
 
-    print("Infering exon number for the CDS...")
+    print("Inferring exon number for the CDS...")
 
     cds_w_exon_nb = {}
 
@@ -242,7 +241,6 @@ def write_tsv(db, data, transcripts_to_remove, gff, flank, refseq_chrom, output_
     print("Sorting data...")
 
     for feature in data:
-        print(feature)
         hgnc_list = [
             i
             for i in feature.attributes["Dbxref"]
@@ -260,15 +258,15 @@ def write_tsv(db, data, transcripts_to_remove, gff, flank, refseq_chrom, output_
 
         if transcript not in transcripts_to_remove:
             feature_nb = data[feature][0].id.split("-")[-1]
-            print(data_to_write)
+
             data_to_write.append([
-                refseq_chrom[feature.seqid], feature.start - 1 - flank,
+                refseq_chrom[feature.chrom], feature.start - 1 - flank,
                 feature.end + flank, hgnc_id, transcript, feature_nb
             ])
         else:
             # some duplicated transcripts span X and Y, final decision is
             # to keep the X copy of the transcript
-            if refseq_chrom[feature.seqid] == "X":
+            if refseq_chrom[feature.chrom] == "X":
                 feature_nb = data[feature][0].id.split("-")[-1]
 
                 data_to_write.append([
@@ -296,8 +294,8 @@ def main(build, gff, flank, output_name):
     cds_exon_nb = infer_exon_number(parents2cds, parents2exons)
     transcripts_to_remove = get_transcripts_to_remove(gff_db, cds_exon_nb)
     write_tsv(
-        gff_db, cds_exon_nb, transcripts_to_remove, gff, flank, output_name,
-        refseq_chrom
+        gff_db, cds_exon_nb, transcripts_to_remove, gff, flank, refseq_chrom,
+        output_name
     )
 
 

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -225,7 +225,7 @@ def get_transcripts_to_remove(db, data):
 
 
 def write_tsv(db, data, transcripts_to_remove, gff, flank, refseq_chrom,
-        output_name=None):
+              output_name=None):
     """ Write tsv
 
     Args:

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -179,6 +179,7 @@ def filter_out_features(feature, refseq_chrom):
         for i in feature.attributes["Dbxref"]
         if "HGNC" in i
     ]
+
     # if there is none or multiple we don't want it
     if len(hgnc_list) != 1:
         return False

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -170,7 +170,7 @@ def filter_out_features(feature, refseq_chrom):
     """
 
     # check if the feature chrom is a refseq chrom
-    if feature.seqid not in refseq_chrom:
+    if feature.chrom not in refseq_chrom:
         return False
 
     # get the hgnc id from the attributes column

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -6,8 +6,9 @@ import gffutils
 from natsort import natsorted
 import pandas as pd
 
+
 def set_chromosome_numbers(genome_build):
-    """ 
+    """
     Replace the RefSeq chromosome numbers with numerical values for chromosomes
     based on the genome build.
     Args:
@@ -15,7 +16,7 @@ def set_chromosome_numbers(genome_build):
 
     Returns:
         refseq_chrom (dict): Dictionary mapping RefSeq chromosome numbers to
-                                simple numeric values for chromosomes 
+                                simple numeric values for chromosomes
     """
 
     if genome_build == "37":


### PR DESCRIPTION
**Changes**

- Add function to select a dictionary converting RefSeq chromosome IDs (e.g. NC_000001.10) to simple numeric chromosomes (e.g. 1). The GRCh37 RefSeq chromosome IDs were previously hardcoded into the script; this new function selects the correct chromosomes to convert based on what build is input: '37' or '38'
- Input this chromosome dictionary to other functions that require chromosome conversion, and had previously used the hardcoded dictionary
- Edit README to add a warning that this release 1.2.0 has updated the first script (gff2tsv) but not the second (refseq_g2t), and therefore the second script may no longer be compatible with the first

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/exon_file_and_g2t_from_new_refseq_gff/11)
<!-- Reviewable:end -->
