### PR TITLE
DI-1428 output exons file with gene symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## First script, gff2tsv
 
-Script to convert refseq GFF to TSV using CDS.
+Script to convert RefSeq GFF to TSV using CDS.
 
 Info on the file:
 
 - coordinates get converted from 1-based to 0-based format.
-- exon number is infered using cds and exon coordinates (any overlap size)
+- exon number is inferred using cds and exon coordinates (any overlap size)
 
 CDS not gathered:
 
@@ -29,20 +29,29 @@ CDS not gathered:
 
 ### How to run
 
-Tested only with a Refseq gff file. Genome build should be input as '37' or '38'.
+Tested only with a Refseq gff file.
+##### Inputs:
+- `-f (int)`: How many bp to add as flank to either side of exons.
+- `-h (str)`: Name of the output exons TSV with HGNC IDs.
+- `-s (str)`: Name of the output exons TSV with gene symbols.
+- `-b (str)`: Genome build should be input as '37' or '38'.
 
 ```bash
-python gff2tsv.py ${gff_file} -f ${flank} -o ${output_name} -s ${gene_symbols_output_name} -b ${genome_build}
+python gff2tsv.py ${gff_file} -f ${flank} -h ${hgnc_output_name} -s ${symbols_output_name} -b ${genome_build}
 ```
 
 ### Outputs
 
-TSV file with the CDS
+One TSV file for CDS with HGNC ID and another which is identical except HGNC IDs are replaced with gene symbols.
 
-Format:
-
+##### Format:
+Exons TSV with HGNC IDs:
 ```tsv
 chrom   start   end HGNC:ID Refseq_transcript_id    exon_nb
+```
+Exons TSV with gene symbols:
+```
+chrom   start   end gene_symbol Refseq_transcript_id    exon_nb
 ```
 
 ## Second script, refseq_g2t

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ CDS not gathered:
 Tested only with a Refseq gff file. Genome build should be input as '37' or '38'.
 
 ```bash
-python gff2tsv.py ${gff_file} -f ${flank} -o ${output_name} -b ${genome_build}
+python gff2tsv.py ${gff_file} -f ${flank} -o ${output_name} -s ${gene_symbols_output_name} -b ${genome_build}
 ```
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ CDS not gathered:
 
 Tested only with a Refseq gff file.
 ##### Inputs:
+- `-g (file)`: RefSeq GFF file.
 - `-f (int)`: How many bp to add as flank to either side of exons.
-- `-h (str)`: Name of the output exons TSV with HGNC IDs.
+- `-o (str)`: Name of the output exons TSV with HGNC IDs.
 - `-s (str)`: Name of the output exons TSV with gene symbols.
 - `-b (str)`: Genome build should be input as '37' or '38'.
 
 ```bash
-python gff2tsv.py ${gff_file} -f ${flank} -h ${hgnc_output_name} -s ${symbols_output_name} -b ${genome_build}
+python gff2tsv.py ${gff_file} -f ${flank} -o ${hgnc_output_name} -s ${symbols_output_name} -b ${genome_build}
 ```
 
 ### Outputs

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -284,7 +284,7 @@ def write_output_tsvs(
         # get the last element i.e. get the actual HGNC id
         hgnc_id = hgnc_list[0].split(":", 1)[-1]
         gene_symbols = feature.attributes.get("gene")
-        gene_symbol = ','.join(gene_symbols)
+        gene_symbol = ','.join(gene_symbols) if gene_symbols else "Unknown"
 
         # get the parent id and extract transcript name from it
         parent = db[feature.attributes["Parent"][0]]

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -264,8 +264,8 @@ def write_tsv(
         # split on ":" i.e. ["HGNC", "HGNC:1"]
         # get the last element i.e. get the actual HGNC id
         hgnc_id = hgnc_list[0].split(":", 1)[-1]
-
-        gene_symbol = feature.attributes.get("gene")
+        gene_symbols = feature.attributes.get("gene")
+        gene_symbol = ','.join(gene_symbols)
 
         # get the parent id and extract transcript name from it
         parent = db[feature.attributes["Parent"][0]]

--- a/gff2tsv.py
+++ b/gff2tsv.py
@@ -224,6 +224,24 @@ def get_transcripts_to_remove(db, data):
     return transcripts_to_remove
 
 
+def write_sorted_data_to_file(filename, data):
+    """
+    Write sorted and filtered data from the GFF to file
+
+    Args:
+        filename (str): Name of file to write out
+        data (list): List containing data to write
+    """
+    try:
+        with open(filename, "w") as outfile:
+            for line in data:
+                str_line = [str(l) for l in line]
+                outfile.write("\t".join(str_line) + "\n")
+    except IOError as e:
+        print(f"Error writing to {filename}: {e}")
+        raise
+
+
 def write_output_tsvs(
     db, data, transcripts_to_remove, gff, flank, refseq_chrom,
     hgnc_output_name=None, symbol_output_name=None
@@ -305,18 +323,10 @@ def write_output_tsvs(
     )
 
     print(f"Writing in {hgnc_output_name}...")
-    with open(hgnc_output_name, "w") as f:
-        for line in sorted_data:
-            str_line = [str(l) for l in line]
-            f.write("\t".join(str_line))
-            f.write("\n")
+    write_sorted_data_to_file(hgnc_output_name, sorted_data)
 
     print(f"Writing in {symbol_output_name}...")
-    with open(symbol_output_name, "w") as f:
-        for line in sorted_symbol:
-            str_line = [str(l) for l in line]
-            f.write("\t".join(str_line))
-            f.write("\n")
+    write_sorted_data_to_file(symbol_output_name, sorted_symbol)
 
 
 def main(build, gff, flank, hgnc_output_name, symbols_output_name):
@@ -333,12 +343,12 @@ def main(build, gff, flank, hgnc_output_name, symbols_output_name):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("gff", help="Refseq GFF file to parse")
+    parser.add_argument("-g", "--gff", help="Refseq GFF file to parse")
     parser.add_argument(
         "-f", "--flank", default=0, type=int, help="Flank to add the features"
     )
     parser.add_argument(
-        "-h", "--hgnc_output_name", help=(
+        "-o", "--hgnc_output_name", help=(
             "Name of the output TSV file with HGNC IDs"
         )
     )


### PR DESCRIPTION
- Small update to write the exons file with gene symbols (which is used with eggd_athena) at the same time as the exons file with HGNC IDs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/exon_file_and_g2t_from_new_refseq_gff/12)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `gff2tsv` script to generate separate TSV files for HGNC IDs and gene symbols.
	- Added new command-line parameter `-s` to specify the output filename for gene symbols.
	- Updated command-line parameter `-o` for specifying the output filename for HGNC IDs.

- **Documentation**
	- Revised README with expanded instructions, including new command-line arguments and output format details.

These updates improve user experience by providing clearer instructions and additional functionality for handling gene symbol data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->